### PR TITLE
Reference official GitHub links

### DIFF
--- a/ploigosWorkflowEverything.yml
+++ b/ploigosWorkflowEverything.yml
@@ -1,6 +1,6 @@
-###########################################
-## Ploigos GitLab CI Workflow - Standard ##
-###########################################
+#############################################
+## Ploigos GitLab CI Workflow - Everything ##
+#############################################
 
 # Do not build tags, or the tag source step will rerun the pipeline
 workflow:

--- a/ploigosWorkflowEverything.yml
+++ b/ploigosWorkflowEverything.yml
@@ -20,13 +20,13 @@ include:
   #  - remote: '$remote_url/-/raw/$gitlabLibraryVersion/var/ploigos_variables.yml'
 
   # Ploigos + GitLab Runner variable setup
-  - remote: 'https://gitlab.apps.tssc.rht-set.com/ploigos/ploigos-gitlab-library/-/raw/main/var/ploigos_variables.yml'
-  - remote: 'https://gitlab.apps.tssc.rht-set.com/ploigos/ploigos-gitlab-library/-/raw/main/var/ploigos_gitlab_variables.yml'
+  - remote: 'https://raw.githubusercontent.com/ploigos/ploigos-gitlab-library/main/var/ploigos_variables.yml'
+  - remote: 'https://raw.githubusercontent.com/ploigos/ploigos-gitlab-library/main/var/ploigos_gitlab_variables.yml'
 
   # Templates
-  - remote: 'https://gitlab.apps.tssc.rht-set.com/ploigos/ploigos-gitlab-library/-/raw/main/templates/ploigos_step_runner.yml'
-  - remote: 'https://gitlab.apps.tssc.rht-set.com/ploigos/ploigos-gitlab-library/-/raw/main/templates/setup_workflow_step_runner.yml'
-  - remote: 'https://gitlab.apps.tssc.rht-set.com/ploigos/ploigos-gitlab-library/-/raw/main/templates/setup_pgp_keys.yml'
+  - remote: 'https://raw.githubusercontent.com/ploigos/ploigos-gitlab-library/main/templates/ploigos_step_runner.yml'
+  - remote: 'https://raw.githubusercontent.com/ploigos/ploigos-gitlab-library/main/templates/setup_workflow_step_runner.yml'
+  - remote: 'https://raw.githubusercontent.com/ploigos/ploigos-gitlab-library/main/templates/setup_pgp_keys.yml'
 
 # These stages come from the includes above
 stages:

--- a/ploigosWorkflowMinimal.yml
+++ b/ploigosWorkflowMinimal.yml
@@ -20,13 +20,13 @@ include:
   #  - remote: '$remote_url/-/raw/$gitlabLibraryVersion/var/ploigos_variables.yml'
 
   # Ploigos + GitLab Runner variable setup
-  - remote: 'https://gitlab.apps.tssc.rht-set.com/ploigos/ploigos-gitlab-library/-/raw/main/var/ploigos_variables.yml'
-  - remote: 'https://gitlab.apps.tssc.rht-set.com/ploigos/ploigos-gitlab-library/-/raw/main/var/ploigos_gitlab_variables.yml'
+  - remote: 'https://raw.githubusercontent.com/ploigos/ploigos-gitlab-library/main/var/ploigos_variables.yml'
+  - remote: 'https://raw.githubusercontent.com/ploigos/ploigos-gitlab-library/main/var/ploigos_gitlab_variables.yml'
 
   # Templates
-  - remote: 'https://gitlab.apps.tssc.rht-set.com/ploigos/ploigos-gitlab-library/-/raw/main/templates/ploigos_step_runner.yml'
-  - remote: 'https://gitlab.apps.tssc.rht-set.com/ploigos/ploigos-gitlab-library/-/raw/main/templates/setup_workflow_step_runner.yml'
-  - remote: 'https://gitlab.apps.tssc.rht-set.com/ploigos/ploigos-gitlab-library/-/raw/main/templates/setup_pgp_keys.yml'
+  - remote: 'https://raw.githubusercontent.com/ploigos/ploigos-gitlab-library/main/templates/ploigos_step_runner.yml'
+  - remote: 'https://raw.githubusercontent.com/ploigos/ploigos-gitlab-library/main/templates/setup_workflow_step_runner.yml'
+  - remote: 'https://raw.githubusercontent.com/ploigos/ploigos-gitlab-library/main/templates/setup_pgp_keys.yml'
 
 # These stages come from the includes above
 stages:

--- a/ploigosWorkflowTypical.yml
+++ b/ploigosWorkflowTypical.yml
@@ -20,13 +20,13 @@ include:
   #  - remote: '$remote_url/-/raw/$gitlabLibraryVersion/var/ploigos_variables.yml'
 
   # Ploigos + GitLab Runner variable setup
-  - remote: 'https://gitlab.apps.tssc.rht-set.com/ploigos/ploigos-gitlab-library/-/raw/main/var/ploigos_variables.yml'
-  - remote: 'https://gitlab.apps.tssc.rht-set.com/ploigos/ploigos-gitlab-library/-/raw/main/var/ploigos_gitlab_variables.yml'
+  - remote: 'https://raw.githubusercontent.com/ploigos/ploigos-gitlab-library/main/var/ploigos_variables.yml'
+  - remote: 'https://raw.githubusercontent.com/ploigos/ploigos-gitlab-library/main/var/ploigos_gitlab_variables.yml'
 
   # Templates
-  - remote: 'https://gitlab.apps.tssc.rht-set.com/ploigos/ploigos-gitlab-library/-/raw/main/templates/ploigos_step_runner.yml'
-  - remote: 'https://gitlab.apps.tssc.rht-set.com/ploigos/ploigos-gitlab-library/-/raw/main/templates/setup_workflow_step_runner.yml'
-  - remote: 'https://gitlab.apps.tssc.rht-set.com/ploigos/ploigos-gitlab-library/-/raw/main/templates/setup_pgp_keys.yml'
+  - remote: 'https://raw.githubusercontent.com/ploigos/ploigos-gitlab-library/main/templates/ploigos_step_runner.yml'
+  - remote: 'https://raw.githubusercontent.com/ploigos/ploigos-gitlab-library/main/templates/setup_workflow_step_runner.yml'
+  - remote: 'https://raw.githubusercontent.com/ploigos/ploigos-gitlab-library/main/templates/setup_pgp_keys.yml'
 
 # These stages come from the includes above
 stages:


### PR DESCRIPTION
Current GitLab reference library is importing files from the test GitLab infrastructure; this update instead points those links to GitHub (specifically, this GitHub repo).

Unfortunately, variable expansion is not supported in import URLs, so the base URL cannot be extracted to a variable and instead must be repeated multiple times.